### PR TITLE
add linebreaks to RUIWebBinary.cpp char array to make some src editor…

### DIFF
--- a/makecpp.js
+++ b/makecpp.js
@@ -38,12 +38,13 @@ function makeCpp() {
                 i++;
                 chars += `${html[i]}`;
                 if (i != (html.length - 1)) chars += ',';
+                if(i%40 == 39) chars += '\n';
             }
 
             let cpp =
 `//Auto generated content.
 unsigned RUI_WEB_BINARY_SIZE = ${html.length/2};
-unsigned char RUI_WEB_BINARY_CONTENT[] = { ${chars} };`
+unsigned char RUI_WEB_BINARY_CONTENT[] = {\n${chars} };`
 
             fs.writeFile(outputCppPath, cpp, (err) => {
                 if (err)


### PR DESCRIPTION
…s less angry

- hey just a tiny change to the formatting.

also I had some trouble with the make file 

```
⭕  oriol@armadilluAir.local ofxRemoteUI-Web git:(master) ❗ make
node makecpp.js
module.js:487
    throw err;
    ^

Error: Cannot find module 'standalone-html'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/oriol/Desktop/ofxRemoteUI-Web/makecpp.js:1:82)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
make: *** [cpp] Error 1
```

And the dat.gui submod is missing the required commit, you probably forgot to push changes:

```
⭕  oriol@armadilluAir.local ofxRemoteUI-Web git:(master) git submodule update --init
Submodule 'dat.gui' (https://github.com/jackosx/dat.gui) registered for path 'dat.gui'
Cloning into '/Users/oriol/Desktop/ofxRemoteUI-Web/dat.gui'...
error: Server does not allow request for unadvertised object 2ea7206fb5e0cda599dc775560553a42b4178498
Fetched in submodule path 'dat.gui', but it did not contain 2ea7206fb5e0cda599dc775560553a42b4178498. Direct fetching of that commit failed.

```